### PR TITLE
Get rid of ansible version checking

### DIFF
--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -39,7 +39,6 @@ from awx.main.utils import (
     build_proot_temp_dir,
     get_licenser
 )
-from awx.main.utils.common import _get_ansible_version
 from awx.main.signals import disable_activity_stream
 from awx.main.constants import STANDARD_INVENTORY_UPDATE_ENV
 from awx.main.utils.pglock import advisory_lock
@@ -136,15 +135,10 @@ class AnsibleInventoryLoader(object):
         # inside of /venv/ansible, so we override the specified interpreter
         # https://github.com/ansible/ansible/issues/50714
         bargs = ['python', ansible_inventory_path, '-i', self.source]
-        ansible_version = _get_ansible_version(ansible_inventory_path[:-len('-inventory')])
-        if ansible_version != 'unknown':
-            this_version = Version(ansible_version)
-            if this_version >= Version('2.5'):
-                bargs.extend(['--playbook-dir', self.source_dir])
-            if this_version >= Version('2.8'):
-                if self.verbosity:
-                    # INFO: -vvv, DEBUG: -vvvvv, for inventory, any more than 3 makes little difference
-                    bargs.append('-{}'.format('v' * min(5, self.verbosity * 2 + 1)))
+        bargs.extend(['--playbook-dir', self.source_dir])
+        if self.verbosity:
+            # INFO: -vvv, DEBUG: -vvvvv, for inventory, any more than 3 makes little difference
+            bargs.append('-{}'.format('v' * min(5, self.verbosity * 2 + 1)))
         logger.debug('Using base command: {}'.format(' '.join(bargs)))
         return bargs
 

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1373,10 +1373,6 @@ class PluginFileInjector(object):
     collection = None
     collection_migration = '2.9'  # Starting with this version, we use collections
 
-    def __init__(self, ansible_version):
-        # This is InventoryOptions instance, could be source or inventory update
-        self.ansible_version = ansible_version
-
     @classmethod
     def get_proper_name(cls):
         if cls.plugin_name is None:

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -73,7 +73,7 @@ from awx.main.utils import (update_scm_url,
                             ignore_inventory_group_removal, extract_ansible_vars, schedule_task_manager,
                             get_awx_version)
 from awx.main.utils.ansible import read_ansible_config
-from awx.main.utils.common import _get_ansible_version, get_custom_venv_choices
+from awx.main.utils.common import get_custom_venv_choices
 from awx.main.utils.external_logging import reconfigure_rsyslog
 from awx.main.utils.safe_yaml import safe_dump, sanitize_jinja
 from awx.main.utils.reload import stop_local_services
@@ -840,12 +840,6 @@ class BaseTask(object):
             else:
                 logger.error('Failed to update %s after %d retries.',
                              self.model._meta.object_name, _attempt)
-
-    def get_ansible_version(self, instance):
-        if not hasattr(self, '_ansible_version'):
-            self._ansible_version = _get_ansible_version(
-                ansible_path=self.get_path_to_ansible(instance, executable='ansible'))
-        return self._ansible_version
 
     def get_path_to(self, *args):
         '''
@@ -2468,7 +2462,7 @@ class RunInventoryUpdate(BaseTask):
         If no private data is needed, return None.
         """
         if inventory_update.source in InventorySource.injectors:
-            injector = InventorySource.injectors[inventory_update.source](self.get_ansible_version(inventory_update))
+            injector = InventorySource.injectors[inventory_update.source]()
             return injector.build_private_data(inventory_update, private_data_dir)
 
     def build_env(self, inventory_update, private_data_dir, isolated, private_data_files=None):
@@ -2496,7 +2490,7 @@ class RunInventoryUpdate(BaseTask):
 
         injector = None
         if inventory_update.source in InventorySource.injectors:
-            injector = InventorySource.injectors[inventory_update.source](self.get_ansible_version(inventory_update))
+            injector = InventorySource.injectors[inventory_update.source]()
 
         if injector is not None:
             env = injector.build_env(inventory_update, env, private_data_dir, private_data_files)
@@ -2609,7 +2603,7 @@ class RunInventoryUpdate(BaseTask):
 
         injector = None
         if inventory_update.source in InventorySource.injectors:
-            injector = InventorySource.injectors[src](self.get_ansible_version(inventory_update))
+            injector = InventorySource.injectors[src]()
 
         if injector is not None:
             content = injector.inventory_contents(inventory_update, private_data_dir)

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1877,13 +1877,6 @@ class TestProjectUpdateCredentials(TestJobExecution):
         assert env['FOO'] == 'BAR'
 
 
-@pytest.fixture
-def mock_ansible_version():
-    with mock.patch('awx.main.tasks._get_ansible_version', mock.MagicMock(return_value='2.10')) as _fixture:
-        yield _fixture
-
-
-@pytest.mark.usefixtures("mock_ansible_version")
 class TestInventoryUpdateCredentials(TestJobExecution):
     @pytest.fixture
     def inventory_update(self):

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -162,23 +162,19 @@ def memoize_delete(function_name):
     return cache.delete(function_name)
 
 
-def _get_ansible_version(ansible_path):
+@memoize()
+def get_ansible_version():
     '''
     Return Ansible version installed.
     Ansible path needs to be provided to account for custom virtual environments
     '''
     try:
-        proc = subprocess.Popen([ansible_path, '--version'],
+        proc = subprocess.Popen(['ansible', '--version'],
                                 stdout=subprocess.PIPE)
         result = smart_str(proc.communicate()[0])
         return result.split('\n')[0].replace('ansible', '').strip()
     except Exception:
         return 'unknown'
-
-
-@memoize()
-def get_ansible_version():
-    return _get_ansible_version('ansible')
 
 
 def get_awx_version():


### PR DESCRIPTION
the main reason this existed was to determine whether we should use the inventory plugin or the inventory script

and well...